### PR TITLE
Added support for Fallout New Vegas

### DIFF
--- a/vortex/falloutnv-post-deploy.desktop
+++ b/vortex/falloutnv-post-deploy.desktop
@@ -1,0 +1,8 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Name=Fallout New Vegas Post-Deploy
+Exec=/home/deck/.pikdum/steam-deck-master/vortex/falloutnv-post-deploy.sh
+Icon=steam_icon_22380
+Terminal=true
+Type=Application
+StartupNotify=false

--- a/vortex/falloutnv-post-deploy.sh
+++ b/vortex/falloutnv-post-deploy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+set -euxo pipefail
+
+FALLOUTNV_INTERNAL="$HOME/.steam/steam/steamapps/common/Fallout New Vegas/"
+FALLOUTNV_EXTERNAL="/run/media/mmcblk0p1/steamapps/common/Fallout New Vegas/"
+
+nvse_setup() {
+    if [ -d "$1" ] &&
+        [ -f "${1}f4se_loader.exe" ] &&
+        [ -f "${1}Fallout4Launcher.exe" ]; then
+        cd "$1"
+        if ! cmp --silent -- "nvse_loader.exe" "FalloutNVLauncher.exe"; then
+            echo "Swapping FalloutNVLauncher.exe for nvse_loader.exe"
+            mv FalloutNVLauncher.exe _FalloutNVLauncher.exe
+            cp nvse_loader.exe FalloutNVLauncher.exe
+        fi
+    fi
+}
+
+nvse_setup "$FALLOUTNV_INTERNAL"
+nvse_setup "$FALLOUTNV_EXTERNAL"
+
+APPDATA_VORTEX="$HOME/.vortex-linux/compatdata/pfx/drive_c/users/steamuser/AppData/Local/falloutnv/"
+APPDATA_INTERNAL="$HOME/.local/share/Steam/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/AppData/Local/falloutnv/"
+APPDATA_EXTERNAL="/run/media/mmcblk0p1/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/AppData/Local/falloutnv/"
+
+echo "Copying loadorder.txt and plugins.txt"
+mkdir -p "$APPDATA_INTERNAL" || true
+mkdir -p "$APPDATA_EXTERNAL" || true
+cp "$APPDATA_VORTEX"/* "$APPDATA_INTERNAL" || true
+cp "$APPDATA_VORTEX"/* "$APPDATA_EXTERNAL" || true
+
+echo "Success! Exiting in 3..."
+sleep 3

--- a/vortex/falloutnv-pre-deploy.sh
+++ b/vortex/falloutnv-pre-deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -euxo pipefail
+
+FALLOUTNV_INTERNAL="$HOME/.steam/steam/steamapps/common/Fallout New Vegas/"
+FALLOUTNV_EXTERNAL="/run/media/mmcblk0p1/steamapps/common/Fallout New Vegas/"
+
+INIFILES_VORTEX="$HOME/.vortex-linux/compatdata/pfx/drive_c/users/steamuser/Documents/My Games/FalloutNV/"
+INIFILES_INTERNAL="$HOME/.local/share/Steam/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/Documents/My Games/FalloutNV/"
+INIFILES_EXTERNAL="/run/media/mmcblk0p1/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/Documents/My Games/FalloutNV/"
+
+if [ -d "$INIFILES_EXTERNAL" ]; then
+    ln -sf "$INIFILES_EXTERNAL"/Fallout.ini "$INIFILES_VORTEX"/
+    ln -sf "$INIFILES_EXTERNAL"/FalloutPrefs.ini "$INIFILES_VORTEX"/
+fi
+
+if [ -d "$INIFILES_INTERNAL" ]; then
+    ln -sf "$INIFILES_INTERNAL"/Fallout.ini "$INIFILES_VORTEX"/
+    ln -sf "$INIFILES_INTERNAL"/FalloutPrefs.ini "$INIFILES_VORTEX"/
+fi
+
+sleep 3

--- a/vortex/install-vortex.sh
+++ b/vortex/install-vortex.sh
@@ -54,6 +54,7 @@ rm -f ~/Desktop/install-vortex.desktop
 ln -sf ~/.local/share/applications/vortex.desktop ~/Desktop/
 ln -sf ~/.pikdum/steam-deck-master/vortex/skyrim-post-deploy.desktop ~/Desktop/
 ln -sf ~/.pikdum/steam-deck-master/vortex/fallout4-post-deploy.desktop ~/Desktop/
+ln -sf ~/.pikdum/steam-deck-master/vortex/falloutnv-post-deploy.desktop ~/Desktop/
 
 mkdir -p /run/media/mmcblk0p1/vortex-downloads || true
 


### PR DESCRIPTION
Hi, I've added post-deploy files and changed the install-vortex.sh to add support for Fallout New Vegas. 
There is an (optional) pre-deploy file to link ini files with the vortex prefix, but I haven't created a .desktop for it. I don't know if it should be run at install, or at the user discretion. What do you think?
I've tested this setup with the VeryLastKiss's New New Vegas patch collection, and it worked well. 
With the ini files linked to vortex prefix, I was even able to launch the game directly from vortex.