### PR TITLE
Update falloutnv-post-deploy.sh

### DIFF
--- a/vortex/falloutnv-post-deploy.sh
+++ b/vortex/falloutnv-post-deploy.sh
@@ -20,9 +20,9 @@ nvse_setup() {
 nvse_setup "$FALLOUTNV_INTERNAL"
 nvse_setup "$FALLOUTNV_EXTERNAL"
 
-APPDATA_VORTEX="$HOME/.vortex-linux/compatdata/pfx/drive_c/users/steamuser/AppData/Local/falloutnv/"
-APPDATA_INTERNAL="$HOME/.local/share/Steam/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/AppData/Local/falloutnv/"
-APPDATA_EXTERNAL="/run/media/mmcblk0p1/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/AppData/Local/falloutnv/"
+APPDATA_VORTEX="$HOME/.vortex-linux/compatdata/pfx/drive_c/users/steamuser/AppData/Local/FalloutNV/"
+APPDATA_INTERNAL="$HOME/.local/share/Steam/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/AppData/Local/FalloutNV/"
+APPDATA_EXTERNAL="/run/media/mmcblk0p1/steamapps/compatdata/22380/pfx/drive_c/users/steamuser/AppData/Local/FalloutNV/"
 
 echo "Copying loadorder.txt and plugins.txt"
 mkdir -p "$APPDATA_INTERNAL" || true


### PR DESCRIPTION
Corrected typo in appdata filepath variables which caused post-deploy script to deploy to the wrong directory.