### PR TITLE
feat: switch from vortex-linux to umu

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,11 @@ after installing, you should have a shortcut on the desktop to install vortex
 
 this will:
 
-0. install SteamLinuxRuntime Sniper
-1. install pikdum/vortex-linux
-2. use ./vortex-linux to set up vortex
-3. add a 'Skyrim Post-Deploy' shortcut to desktop
+1. use umu to set up vortex
+2. add a 'Skyrim Post-Deploy' shortcut to desktop
    * needs to be run every time after you change mods in Vortex
-   * also adds a 'Fallout 4 Post-Deploy'
-4. map J: to internal games and K: to sd card games
+   * also adds a 'Fallout 4 Post-Deploy' and some others
+3. map J: to internal games and K: to sd card games
    * E: is the sd card root
 
 after modding, run games normally through game mode rather than launching through vortex
@@ -149,6 +147,7 @@ rm -rf ~/.pikdum/
 rm -rf ~/.vortex-linux/
 rm -rf ~/.local/share/applications/vortex.*
 # manually remove desktop icons
+# uninstall umu proton builds/etc. if desired
 ```
 
 ## old version uninstall

--- a/post-install.sh
+++ b/post-install.sh
@@ -15,6 +15,9 @@ if [ ! -f "$HOME/.local/share/applications/vortex.desktop" ]; then
     echo "Creating Vortex install desktop shortcut..."
     ln -s ~/.pikdum/steam-deck-master/vortex/install-vortex.desktop ~/Desktop/install-vortex.desktop || true
 else
+    # update .desktop file to make sure it's up to date
+    cp ~/.pikdum/steam-deck-master/vortex/vortex.desktop ~/.local/share/applications/
+
     echo "Creating Vortex desktop shortcuts..."
     ln -sf ~/.local/share/applications/vortex.desktop ~/Desktop/
     ln -sf ~/.pikdum/steam-deck-master/vortex/skyrim-post-deploy.desktop ~/Desktop/

--- a/post-install.sh
+++ b/post-install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+# Clean up old proton builds
+rm -rf ~/.vortex-linux/proton-builds/
+
 echo "Templating files..."
 pushd ~/.pikdum/steam-deck-master/
 find . -type f -name "*.in" -exec sh -c 'envsubst < "$1" > "${1%.in}" && chmod +x "${1%.in}"' _ {} \;
@@ -13,6 +16,7 @@ if [ ! -f "$HOME/.local/share/applications/vortex.desktop" ]; then
     ln -s ~/.pikdum/steam-deck-master/vortex/install-vortex.desktop ~/Desktop/install-vortex.desktop || true
 else
     echo "Creating Vortex desktop shortcuts..."
+    ln -sf ~/.local/share/applications/vortex.desktop ~/Desktop/
     ln -sf ~/.pikdum/steam-deck-master/vortex/skyrim-post-deploy.desktop ~/Desktop/
     ln -sf ~/.pikdum/steam-deck-master/vortex/skyrimle-post-deploy.desktop ~/Desktop/
     ln -sf ~/.pikdum/steam-deck-master/vortex/fallout4-post-deploy.desktop ~/Desktop/
@@ -20,27 +24,8 @@ else
     ln -sf ~/.pikdum/steam-deck-master/vortex/fallout3-post-deploy.desktop ~/Desktop/
     ln -sf ~/.pikdum/steam-deck-master/vortex/oblivion-post-deploy.desktop ~/Desktop/
 
-    VORTEX_LINUX="v1.3.4"
-    PROTON_BUILD="GE-Proton9-23"
-
-    PROTON_URL="https://github.com/GloriousEggroll/proton-ge-custom/releases/download/$PROTON_BUILD/$PROTON_BUILD.tar.gz"
-
-    echo "Updating vortex-linux..."
-    pushd ~/.pikdum/steam-deck-master/vortex/
-    rm -rf vortex-linux || true
-    wget https://github.com/pikdum/vortex-linux/releases/download/$VORTEX_LINUX/vortex-linux
-    chmod +x vortex-linux
-    popd
-
-    ~/.pikdum/steam-deck-master/vortex/vortex-linux setupVortexDesktop
-
-    if [ ! -d "$HOME/.vortex-linux/proton-builds/$PROTON_BUILD" ]; then
-        echo "Removing old Proton builds..."
-        rm -rf $HOME/.vortex-linux/proton-builds/*
-        echo "Upgrading Proton to $PROTON_BUILD..."
-        ~/.pikdum/steam-deck-master/vortex/vortex-linux downloadProton "$PROTON_URL"
-        ~/.pikdum/steam-deck-master/vortex/vortex-linux setProton "$PROTON_BUILD"
-    fi
+    echo "Vortex is already installed, updating umu-launcher..."
+    ~/.pikdum/steam-deck-master/vortex/install-umu.sh
 fi
 
 MOUNTPOINT="$(findmnt /dev/mmcblk0p1 -o TARGET -n)"

--- a/post-install.sh
+++ b/post-install.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Clean up old proton builds
+# Clean up data from old implementation
 rm -rf ~/.vortex-linux/proton-builds/
+rm -rf ~/.pikdum/steam-deck-master/vortex/vortex-linux
 
 echo "Templating files..."
 pushd ~/.pikdum/steam-deck-master/

--- a/vortex/install-umu.sh
+++ b/vortex/install-umu.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+UMU_VERSION="1.2.6"
+UMU_URL="https://github.com/Open-Wine-Components/umu-launcher/releases/download/$UMU_VERSION/umu-launcher-$UMU_VERSION-zipapp.tar"
+UMU_DIR="$HOME/.pikdum/umu"
+
+echo "Installing umu-launcher $UMU_VERSION..."
+
+# Create umu directory
+mkdir -p "$UMU_DIR"
+cd "$UMU_DIR"
+
+# Download umu-launcher
+echo "Downloading umu-launcher from $UMU_URL..."
+wget -O "umu-launcher-$UMU_VERSION-zipapp.tar" "$UMU_URL"
+
+# Extract with strip-components to remove leading directory
+echo "Extracting umu-launcher..."
+tar --strip-components=1 -xf "umu-launcher-$UMU_VERSION-zipapp.tar"
+
+# Make all files executable
+chmod +x *
+
+# Clean up downloaded archive
+rm "umu-launcher-$UMU_VERSION-zipapp.tar"
+
+echo "umu-launcher installation completed successfully!"

--- a/vortex/vortex-wrapper.sh
+++ b/vortex/vortex-wrapper.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+export WINEPREFIX="$HOME/.vortex-linux/compatdata"
+
+cd "$HOME/.vortex-linux/compatdata/drive_c/Program Files/Black Tree Gaming Ltd/Vortex" || exit 1
+
+# Check for -d or -i with no "nxm" in the following argument
+if [[ ("$1" == "-d" || "$1" == "-i") && "$2" != *"nxm"* ]]; then
+  echo "No url provided, ignoring $1"
+  exec ~/.pikdum/umu/umu-run Vortex.exe
+else
+  export PROTON_VERB="runinprefix"
+  exec ~/.pikdum/umu/umu-run Vortex.exe "$@"
+fi

--- a/vortex/vortex.desktop.in
+++ b/vortex/vortex.desktop.in
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Categories=Game;Utility
+Name=Vortex
+MimeType=x-scheme-handler/nxm;x-scheme-handler/nxm-protocol
+Terminal=false
+X-KeepTerminal=false
+Path=$HOME/.vortex-linux/compatdata/drive_c/Program Files/Black Tree Gaming Ltd/Vortex
+Exec=$HOME/.pikdum/steam-deck-master/vortex/vortex-wrapper.sh -d %u
+Icon=$HOME/.pikdum/steam-deck-master/vortex/vortex.ico


### PR DESCRIPTION
I built `vortex-linux` a while back to help simplify using Proton + Vortex for this project, but it's extra code to maintain and there are some issues with it. This switches to use `umu` instead, to automatically:
* keep proton up-to-date
* wire up steam linux runtime

Hopefully maintains backwards compatibility by using the same `WINEPREFIX`.